### PR TITLE
Work around a bug in mongoid/bson-ruby

### DIFF
--- a/lib/mongoid/time_with_named_zone.rb
+++ b/lib/mongoid/time_with_named_zone.rb
@@ -10,7 +10,7 @@ module Mongoid
       # Convert the object from its mongo friendly ruby type to this type
       def demongoize(object)
         return nil unless object.is_a? Hash
-        object.symbolize_keys!
+        object = object.to_h.symbolize_keys!
         return nil unless object[:time] && object[:zone]
         object[:time].in_time_zone(object[:zone])
       end

--- a/lib/mongoid/time_with_named_zone/version.rb
+++ b/lib/mongoid/time_with_named_zone/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module TimeWithNamedZone
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end

--- a/spec/time_with_zone_spec.rb
+++ b/spec/time_with_zone_spec.rb
@@ -2,57 +2,71 @@ require 'mongoid/time_with_named_zone'
 
 describe Mongoid::TimeWithNamedZone do
   describe '#mongoize' do
-    subject { Mongoid::TimeWithNamedZone.mongoize(time) }
+    let(:time) { Time.utc(2010, 11, 19) }
+    subject { described_class.mongoize(time) }
+
+    it { is_expected.to eq(time: Time.utc(2010, 11, 19), zone: 'UTC') }
 
     context 'time in Lima zone' do
-      let(:time) { Time.utc(2010, 11, 19).in_time_zone 'Lima' }
+      let(:time) { super().in_time_zone 'Lima' }
       it { is_expected.to eq(time: Time.utc(2010, 11, 19), zone: 'Lima') }
     end
 
-    context 'Time object' do
-      let(:time) { Time.utc(2010, 11, 19) }
-      it { is_expected.to eq(time: Time.utc(2010, 11, 19), zone: 'UTC') }
-    end
-
-    context 'Date object' do
+    context 'when time is an instance of `Date`' do
       let(:time) { Date.new(2010, 11, 29) }
       it { is_expected.to eq(time: Time.utc(2010, 11, 29), zone: 'UTC') }
     end
 
-    context 'DateTime object' do
+    context 'when time is an instanc of `DateTime`' do
       let(:time) { DateTime.new(2010, 11, 29) }
       it { is_expected.to eq(time: Time.utc(2010, 11, 29), zone: 'UTC') }
     end
 
-    context 'Hash' do
+    context 'when time is actually a `Hash`' do
       let(:time) { { time: Time.utc(2010, 11, 29), zone: 'UTC' } }
       it { is_expected.to eq(time: Time.utc(2010, 11, 29), zone: 'UTC') }
     end
   end
 
   describe '.demongoize' do
+    let(:hash) { { 'time' => Time.utc(2010, 11, 19), 'zone' => 'Pacific/Auckland' } }
+    subject { described_class.demongoize(hash) }
+
     it 'returns time in saved zone' do
-      hash = { 'time' => Time.utc(2010, 11, 19), 'zone' => 'Pacific/Auckland' }
-      demongoized_value = Mongoid::TimeWithNamedZone.demongoize(hash)
-      expect(demongoized_value).to eq(Time.new(2010, 11, 19, '+13:00'))
+      expect(subject).to eq(Time.new(2010, 11, 19, '+13:00'))
     end
 
-    it 'works with symbolized keys' do
-      hash = { time: Time.utc(2010, 11, 19), zone: 'Pacific/Auckland' }
-      demongoized_value = Mongoid::TimeWithNamedZone.demongoize(hash)
-      expect(demongoized_value).to eq(Time.new(2010, 11, 19, '+13:00'))
+    context 'When the hash has symbol keys' do
+      let(:hash) { super().stringify_keys }
+
+      it 'returns time in saved zone' do
+        expect(subject).to eq(Time.new(2010, 11, 19, '+13:00'))
+      end
     end
 
-    it 'returns nil for blank object' do
-      expect(Mongoid::TimeWithNamedZone.demongoize(nil)).to eq(nil)
+    context 'When the payload is nil' do
+      let(:hash) { nil }
+      it { is_expected.to eq(nil) }
     end
 
-    it 'returns nil for empty hash' do
-      expect(Mongoid::TimeWithNamedZone.demongoize({})).to eq(nil)
+    context 'When the payload is empty' do
+      let(:hash) { {} }
+      it { is_expected.to eq(nil) }
     end
 
-    it 'returns nil for hash without time' do
-      expect(Mongoid::TimeWithNamedZone.demongoize('zone' => 'UTC')).to eq(nil)
+    context 'When the hash has no time' do
+      let(:hash) { super().tap { |h| h.delete('time') } }
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'When the hash has no zone' do
+      let(:hash) { super().tap { |h| h.delete('zone') } }
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'When the hash is actually an instance of `BSON::Document`' do
+      let(:hash) { BSON::Document.new(super()) }
+      it { is_expected.to eq(Time.new(2010, 11, 19, '+13:00')) }
     end
   end
 end


### PR DESCRIPTION
Some versions of `BSON::Document` masquerade as a `Hash` but don't provide that most hash-like of properties - the ability to index on keys using `#[]`.  We work around this by explicitly casting the input object into a hash before trying to deserialize it.